### PR TITLE
Fixed incorrect values from showing in multiplayer

### DIFF
--- a/src/Artemis.GSI.Valheim/Patches/Player/PlayerUpdatePatch.cs
+++ b/src/Artemis.GSI.Valheim/Patches/Player/PlayerUpdatePatch.cs
@@ -11,15 +11,18 @@ namespace Artemis.GSI.Valheim.Patches
 
         public static void Postfix(ref Player __instance)
         {
-            Player.HealthCurrent = __instance.GetHealth();
-            Player.HealthMax = __instance.GetMaxHealth();
-            Player.StaminaCurrent = __instance.GetStamina();
-            Player.StaminaMax = __instance.GetMaxStamina();
-            Player.WeightCurrent = __instance.GetInventory().GetTotalWeight();
-            Player.WeightMax = __instance.GetMaxCarryWeight();
-            Player.InShelter = __instance.InShelter();
-            Player.Effects = __instance.GetSEMan().GetStatusEffects().ConvertAll(se => se.name);
-            Player.ForsakenPower = __instance.GetGuardianPowerName();
+            if (__instance.IsOwner())
+            {
+                Player.HealthCurrent = __instance.GetHealth();
+                Player.HealthMax = __instance.GetMaxHealth();
+                Player.StaminaCurrent = __instance.GetStamina();
+                Player.StaminaMax = __instance.GetMaxStamina();
+                Player.WeightCurrent = __instance.GetInventory().GetTotalWeight();
+                Player.WeightMax = __instance.GetMaxCarryWeight();
+                Player.InShelter = __instance.InShelter();
+                Player.Effects = __instance.GetSEMan().GetStatusEffects().ConvertAll(se => se.name);
+                Player.ForsakenPower = __instance.GetGuardianPowerName();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes a problem with showing incorrect values in multiplayer and makes sure that the user is actually the owner of the player